### PR TITLE
grpclb: update picker synchronously on config update

### DIFF
--- a/balancer/grpclb/grpclb_test.go
+++ b/balancer/grpclb/grpclb_test.go
@@ -1651,3 +1651,60 @@ func (s) TestGRPCLBStatsQuashEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// Test ensures the picker is updated synchronously upon receipt
+// of a configuration update.
+func (s) TestPickerUpdatedSynchronouslyOnConfigUpdate(t *testing.T) {
+	// Override the newPickerUpdated to ensure picker was updated.
+	pickerUpdated := make(chan struct{}, 1)
+	origNewPickerUpdated := newPickerUpdated
+	newPickerUpdated = func() { pickerUpdated <- struct{}{} }
+	defer func() { newPickerUpdated = origNewPickerUpdated }()
+
+	// Override the clientConn update hook to get notified.
+	clientConnUpdateDone := make(chan struct{}, 1)
+	origClientConnUpdateHook := clientConnUpdateHook
+	clientConnUpdateHook = func() {
+		t.Logf("Triggering Client Conn Update Hook.")
+		clientConnUpdateDone <- struct{}{}
+	}
+	defer func() { clientConnUpdateHook = origClientConnUpdateHook }()
+
+	tss, cleanup, err := startBackendsAndRemoteLoadBalancer(t, 1, "", nil)
+	if err != nil {
+		t.Fatalf("failed to create new load balancer: %v", err)
+	}
+	defer cleanup()
+
+	// Connect to the test backends.
+	r := manual.NewBuilderWithScheme("whatever")
+	dopts := []grpc.DialOption{
+		grpc.WithResolvers(r),
+		grpc.WithTransportCredentials(&serverNameCheckCreds{}),
+		grpc.WithContextDialer(fakeNameDialer),
+	}
+	cc, err := grpc.Dial(r.Scheme()+":///"+beServerName, dopts...)
+	if err != nil {
+		t.Fatalf("Failed to dial to the backend %v", err)
+	}
+	defer cc.Close()
+
+	// Push a service config with grpclb as the load balancing policy and
+	// configure pick_first as its child policy.
+	rs := resolver.State{ServiceConfig: r.CC.ParseServiceConfig(`{"loadBalancingConfig":[{"grpclb":{"childPolicy":[{"pick_first":{}}]}}]}`)}
+
+	// Push a resolver update with the remote balancer address specified via
+	// attributes.
+	r.UpdateState(grpclbstate.Set(rs, &grpclbstate.State{BalancerAddresses: []resolver.Address{{Addr: tss.lbAddr, ServerName: lbServerName}}}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	select {
+	case <-pickerUpdated:
+		t.Log("Picker was updated synchronously on receipt of configuration update.")
+	case <-clientConnUpdateDone:
+		t.Fatal("Client conn update was completed before picker update.")
+	case <-ctx.Done():
+		t.Fatal("Timed out waiting for picker update upon receiving a configuration update")
+	}
+}


### PR DESCRIPTION
https://github.com/grpc/grpc-go/issues/5469 recommends an audit of existing LB policies to ensure that they update their pickers synchronously upon receipt of a configuration update. grpclb does not update picker synchronously.

What does this PR do?
This PR ensures that every time configuration update is triggered, picker is updated synchronously.

RELEASE NOTES:

- grpclb: update picker synchronously on receipt of configuration update.