### PR TITLE
clusterimpl: send single picker update synchronously on config update.

### DIFF
--- a/xds/internal/balancer/clusterimpl/clusterimpl.go
+++ b/xds/internal/balancer/clusterimpl/clusterimpl.go
@@ -56,6 +56,10 @@ const (
 var (
 	connectedAddress  = internal.ConnectedAddress.(func(balancer.SubConnState) resolver.Address)
 	errBalancerClosed = fmt.Errorf("%s LB policy is closed", Name)
+	// Below function is no-op in actual code, but can be overridden in
+	// tests to give tests visibility into exactly when certain events happen.
+	clientConnUpdateHook = func() {}
+	newPickerUpdated     = func() {}
 )
 
 func init() {
@@ -102,11 +106,19 @@ type clusterImplBalancer struct {
 	lrsServer        *bootstrap.ServerConfig
 	loadWrapper      *loadstore.Wrapper
 
+	// Set during UpdateClientConnState when pushing updates to child policy.
+	// Prevents state updates from child policy causing new pickers to be sent
+	// up the channel. Cleared after child policy have processed the
+	// updates sent to them, after which a new picker is sent up the channel.
+	inhibitPickerUpdates bool
+
 	clusterNameMu sync.Mutex
 	clusterName   string
 
 	serializer       *grpcsync.CallbackSerializer
 	serializerCancel context.CancelFunc
+
+	mu sync.Mutex // guards childState and inhibitPickerUpdates
 
 	// childState/drops/requestCounter keeps the state used by the most recently
 	// generated picker.
@@ -199,6 +211,8 @@ func (b *clusterImplBalancer) updateLoadStore(newConfig *LBConfig) error {
 }
 
 func (b *clusterImplBalancer) updateClientConnState(s balancer.ClientConnState) error {
+	defer clientConnUpdateHook()
+
 	if b.logger.V(2) {
 		b.logger.Infof("Received configuration: %s", pretty.ToJSON(s.BalancerConfig))
 	}
@@ -242,24 +256,32 @@ func (b *clusterImplBalancer) updateClientConnState(s balancer.ClientConnState) 
 	}
 
 	b.config = newConfig
-
-	b.telemetryLabels = newConfig.TelemetryLabels
-	dc := b.handleDropAndRequestCount(newConfig)
-	if dc != nil && b.childState.Picker != nil {
-		b.ClientConn.UpdateState(balancer.State{
-			ConnectivityState: b.childState.ConnectivityState,
-			Picker:            b.newPicker(dc),
-		})
-	}
-
 	// Addresses and sub-balancer config are sent to sub-balancer.
-	return b.child.UpdateClientConnState(balancer.ClientConnState{
+	err = b.child.UpdateClientConnState(balancer.ClientConnState{
 		ResolverState:  s.ResolverState,
 		BalancerConfig: parsedCfg,
 	})
+
+	b.mu.Lock()
+	b.inhibitPickerUpdates = false
+	childState := b.childState
+	b.mu.Unlock()
+	b.telemetryLabels = newConfig.TelemetryLabels
+	dc := b.handleDropAndRequestCount(newConfig)
+	if dc != nil && childState.Picker != nil {
+		b.ClientConn.UpdateState(balancer.State{
+			ConnectivityState: childState.ConnectivityState,
+			Picker:            b.newPicker(dc),
+		})
+	}
+	newPickerUpdated()
+	return err
 }
 
 func (b *clusterImplBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
+	b.mu.Lock()
+	b.inhibitPickerUpdates = true
+	b.mu.Unlock()
 	// Handle the update in a blocking fashion.
 	errCh := make(chan error, 1)
 	callback := func(context.Context) {


### PR DESCRIPTION
#7210 recommends an audit of existing LB policies to ensure that they update their pickers synchronously upon receipt of a configuration update. clusterimpl does not update picker synchronously before because of multiple reasons, one is on reciept of configuration update, process of switching the child policies was aysnchronous, and second is it was not waiting for the child policy config to be update first, before returning from `UpdateClientConnState`.

What does this PR do?
This PR ensures that every time configuration update is triggered, picker is updated synchronously.

RELEASE NOTES:

- clusterimpl: update picker synchronously on receipt of configuration update.